### PR TITLE
Fix typo in GMT script of "007_map_SKS_SKKS_pierce_points"

### DIFF
--- a/007_map_SKS_SKKS_pierce_points/Scan_SKS_SKKS_figs.gmt
+++ b/007_map_SKS_SKKS_pierce_points/Scan_SKS_SKKS_figs.gmt
@@ -162,7 +162,7 @@ outfile=SKS_SKKS_pathconn.dat
 outfile2=SKS_SKKS_pathconn_SI.dat
 
 awk ' {print $1,$2} NR % 2 == 0 { print ">"; }' $infile > $outfile
-# only extract discrepant ones for SI visulization
+# only extract discrepant ones for SI visualization
 awk ' {if ($3 == "yes") print $1,$2} NR % 2 == 0 { print ">"; }' $infile > $outfile2 
 
 # plot connecting lines between SKS/SKKS pierce points


### PR DESCRIPTION
This PR aims to fix a typo in the Jupyter notebook of "007_map_SKS_SKKS_pierce_points".